### PR TITLE
Provide admin ability to delete operations in a room, maintain numMembers in room

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       LOG_LEVEL: DEBUG
       MONGO_CONNECTION_URL: mongodb://mongo:27017
       PPROF: 1
+      ADMIN_KEY: local
 
   mongo:
     image: mongo:latest

--- a/postman/NIME 2020 - Live.postman_environment.json
+++ b/postman/NIME 2020 - Live.postman_environment.json
@@ -1,0 +1,24 @@
+{
+	"id": "bfe334cd-09f9-4b25-b65a-36998f30b127",
+	"name": "NIME 2020 - Live",
+	"values": [
+		{
+			"key": "HOSTNAME",
+			"value": "https://nime2020.rytrose.com",
+			"enabled": true
+		},
+		{
+			"key": "ROOM_NAME",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "ADMIN_KEY",
+			"value": "",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2020-05-07T02:07:38.551Z",
+	"_postman_exported_using": "Postman/7.23.0"
+}

--- a/postman/NIME 2020 - Local.postman_environment.json
+++ b/postman/NIME 2020 - Local.postman_environment.json
@@ -1,0 +1,24 @@
+{
+	"id": "64746dc0-65a9-4b6c-bfa1-ff828845661e",
+	"name": "NIME 2020 - Local",
+	"values": [
+		{
+			"key": "HOSTNAME",
+			"value": "http://localhost:8000",
+			"enabled": true
+		},
+		{
+			"key": "ADMIN_KEY",
+			"value": "local",
+			"enabled": true
+		},
+		{
+			"key": "ROOM_NAME",
+			"value": "",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2020-05-07T02:07:09.685Z",
+	"_postman_exported_using": "Postman/7.23.0"
+}

--- a/postman/NIME 2020.postman_collection.json
+++ b/postman/NIME 2020.postman_collection.json
@@ -1,0 +1,36 @@
+{
+	"info": {
+		"_postman_id": "40307282-7d24-4df6-8163-4298b26e760c",
+		"name": "NIME 2020",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Delete Operations for Room",
+			"request": {
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "X-Admin-Key",
+						"value": "{{ADMIN_KEY}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{HOSTNAME}}/admin/rooms/{{ROOM_NAME}}/operations",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"admin",
+						"rooms",
+						"{{ROOM_NAME}}",
+						"operations"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/server/api.go
+++ b/server/api.go
@@ -9,14 +9,16 @@ import (
 
 // Message types
 const (
-	TypeAnnounce        = "announce"        // [Client->Server] Provides a user ID to the client
-	TypeEnterRoom       = "enterRoom"       // [Client->Server] Client associates with a room, and requests the current state
-	TypeExitRoom        = "exitRoom"        // [Client->Server] Client disassociates with a room
-	TypeOperation       = "operation"       // [Client->Server] Client makes and operation
-	TypeOperationUpdate = "operationUpdate" // [Server->Client] Server disseminates an operation to all Clients in a room
-	TypeRequestState    = "requestState"    // [Server->Client] Server asks a Client for the full state of the room
-	TypeState           = "state"           // [Client->Server] Client sends the full state to the server
-	TypeClearState      = "clearState"      // [Server->Client] Server tells a Client to clear the current state
+	TypeAnnounce  = "announce"  // [Client->Server] Provides a user ID to the client
+	TypeEnterRoom = "enterRoom" // [Client->Server] Client associates with a room, and requests the current state
+	TypeExitRoom  = "exitRoom"  // [Client->Server] Client disassociates with a room
+	TypeOperation = "operation" // [Client->Server] Client makes and operation
+	TypeState     = "state"     // [Client->Server] Client sends the full state to the server
+
+	TypeOperationUpdate  = "operationUpdate"  // [Server->Client] Server disseminates an operation to all Clients in a room
+	TypeRequestState     = "requestState"     // [Server->Client] Server asks a Client for the full state of the room
+	TypeClearState       = "clearState"       // [Server->Client] Server tells a Client to clear the current state
+	TypeNumMembersUpdate = "numMembersUpdate" // [Server->Client] Server tells a Client how many members are in the room
 )
 
 // Message is the superset of the object websocket clients send.
@@ -40,22 +42,22 @@ func dispatch(c *Client, b []byte) {
 
 	switch m.Type {
 	case TypeAnnounce:
-		Announce(c, m)
+		AnnounceHandler(c, m)
 	case TypeEnterRoom:
-		res := EnterRoom(c, m)
+		res := EnterRoomHandler(c, m)
 		c.Send(res)
 	case TypeExitRoom:
-		res := ExitRoom(c, m)
+		res := ExitRoomHandler(c, m)
 		c.Send(res)
 	case TypeOperation:
-		res, err := Operate(c, m)
+		res, err := OperationHandler(c, m)
 		if err != nil {
 			c.Send(err)
 			break
 		}
 		c.Room.Broadcast(res, c)
 	case TypeState:
-		State(c, m)
+		StateHandler(c, m)
 	default:
 		log.Warnf("message type \"%s\" not implemented", m.Type)
 	}

--- a/server/api.go
+++ b/server/api.go
@@ -9,13 +9,14 @@ import (
 
 // Message types
 const (
-	TypeAnnounce        = "announce"
-	TypeEnterRoom       = "enterRoom"
-	TypeExitRoom        = "exitRoom"
-	TypeOperation       = "operation"
-	TypeOperationUpdate = "operationUpdate"
-	TypeRequestState    = "requestState"
-	TypeState           = "state"
+	TypeAnnounce        = "announce"        // [Client->Server] Provides a user ID to the client
+	TypeEnterRoom       = "enterRoom"       // [Client->Server] Client associates with a room, and requests the current state
+	TypeExitRoom        = "exitRoom"        // [Client->Server] Client disassociates with a room
+	TypeOperation       = "operation"       // [Client->Server] Client makes and operation
+	TypeOperationUpdate = "operationUpdate" // [Server->Client] Server disseminates an operation to all Clients in a room
+	TypeRequestState    = "requestState"    // [Server->Client] Server asks a Client for the full state of the room
+	TypeState           = "state"           // [Client->Server] Client sends the full state to the server
+	TypeClearState      = "clearState"      // [Server->Client] Server tells a Client to clear the current state
 )
 
 // Message is the superset of the object websocket clients send.

--- a/server/client/js/main.js
+++ b/server/client/js/main.js
@@ -49,6 +49,9 @@ firebase.auth().onAuthStateChanged((user) => {
             socket.register("clearState", (m) => {
                 $("#operations").empty();
             });
+            socket.register("numMembersUpdate", (m) => {
+                $("#numMembers").text(m.numMembers);
+            });
 
             // Announce this user 
             socket.addEventListener("open", () => {
@@ -90,6 +93,7 @@ rooms.where('active', '==', true).onSnapshot((snapshot) => {
                     .then(res => {
                         $("#currentRoom").html(`
                         <h3>Welcome to room ${res.roomDoc.RoomName}!</h3>
+                        <p><span id="numMembers">${res.roomDoc.NumMembers}</span> people in this room</p>
                         <button id="operate">Commit operation</button>
                         <button id="exitRoom">Exit ${res.roomDoc.RoomName}</button>
                         <div id="operations">Most recent operations:</div>

--- a/server/client/js/main.js
+++ b/server/client/js/main.js
@@ -46,6 +46,9 @@ firebase.auth().onAuthStateChanged((user) => {
             socket.register("operationUpdate", (m) => {
                 $("#operations").append(`<p>${JSON.stringify(m.operation)}</p>`);
             });
+            socket.register("clearState", (m) => {
+                $("#operations").empty();
+            });
 
             // Announce this user 
             socket.addEventListener("open", () => {

--- a/server/client/templates/index.html
+++ b/server/client/templates/index.html
@@ -25,7 +25,6 @@
     <!-- TODO: Add SDKs for Firebase products that you want to use
          https://firebase.google.com/docs/web/setup#available-libraries -->
     <!-- <script src="https://www.gstatic.com/firebasejs/7.14.1/firebase-analytics.js"></script> -->
-    <script src="https://www.gstatic.com/firebasejs/7.14.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/7.14.1/firebase-auth.js"></script>
     <script src="https://www.gstatic.com/firebasejs/7.14.1/firebase-firestore.js"></script>
     <script src="https://www.gstatic.com/firebasejs/7.14.1/firebase-database.js"></script>

--- a/server/db.go
+++ b/server/db.go
@@ -40,11 +40,11 @@ type RoomDoc struct {
 
 // OpBucketDoc is a document that stores operations.
 type OpBucketDoc struct {
-	ID     primitive.ObjectID `bson:"_id"`
-	RoomID string             `bson:"room_id"`
-	Bucket int                `bson:"bucket"`
-	Count  int                `bson:"count"`
-	Ops    []bson.M           `bson:"operations"`
+	ID       primitive.ObjectID `bson:"_id"`
+	RoomName string             `bson:"room_name"`
+	Bucket   int                `bson:"bucket"`
+	Count    int                `bson:"count"`
+	Ops      []bson.M           `bson:"operations"`
 }
 
 // NewDB creates a connection to the mongodb.
@@ -255,4 +255,42 @@ func (db *DB) GetAllOperations(roomName string) ([]bson.M, error) {
 		all = append(all, bucketDoc.Ops...)
 	}
 	return all, nil
+}
+
+// DeleteAllOperations deletes all operations for a given room.
+func (db *DB) DeleteAllOperations(roomName string) error {
+	// Delete all buckets
+	ctx, _ := context.WithTimeout(context.Background(), DBTimeoutOp*time.Second)
+	query := bson.M{"room_name": roomName}
+
+	_, err := db.operationBucketsCol.DeleteMany(ctx, query)
+	if err != nil {
+		return fmt.Errorf("database delete many error: %s", err)
+	}
+
+	// Set num_buckets to one
+	ctx, _ = context.WithTimeout(context.Background(), DBTimeoutOp*time.Second)
+	query = bson.M{"room_name": roomName}
+	operation := bson.M{"$set": bson.M{"num_buckets": 1}}
+	opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
+
+	roomDoc := &RoomDoc{}
+	err = db.roomCol.FindOneAndUpdate(ctx, query, operation, opts).Decode(roomDoc)
+	if err != nil {
+		return fmt.Errorf("database update room num_buckets error: %s", err)
+	}
+	if roomDoc.NumBuckets != 1 {
+		return fmt.Errorf("num_buckets of room %s was not set to 1 after deleting all operations", roomName)
+	}
+
+	// Reset all clients
+	room, ok := rooms.Get(roomName)
+	if !ok {
+		return fmt.Errorf("server is not tracking room %s, but its operations have been deleted", roomName)
+	}
+	room.Broadcast(bson.M{
+		"type": TypeClearState,
+	})
+
+	return nil
 }

--- a/server/go.sum
+++ b/server/go.sum
@@ -207,6 +207,7 @@ github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHM
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.mongodb.org/mongo-driver v1.3.2 h1:IYppNjEV/C+/3VPbhHVxQ4t04eVW0cLp0/pNdW++6Ug=
 go.mongodb.org/mongo-driver v1.3.2/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
+go.mongodb.org/mongo-driver v1.3.3 h1:9kX7WY6sU/5qBuhm5mdnNWdqaDAQKB2qSZOd5wMEPGQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
This PR adds two things:

1. A mechanism to delete all operations in a room
- This is done by a `DELETE` request to `/admin/rooms/:roomName/operations`
- The request requires an `X-Admin-Key` header so that no one can willy-nilly wreck our shit (not the most secure but it's something lol)
  - Locally, it's just expecting `local`, but I'll be setting a random string for when it's deployed, which I'll send you/point you to on GCP console
- Adds a command type `clearState` that the server broadcasts to clients, upon which clients should clear their state because the operations in that room have been deleted

2. Persisting the number of members in each room in MongoDB
- Adds a command type `numMembersUpdate` that the server broadcasts to clients, so they can know how many members are in the room when it changes

